### PR TITLE
Fix typos in src/Class.js comments

### DIFF
--- a/src/Class.js
+++ b/src/Class.js
@@ -4,7 +4,7 @@
 
 	Class.extend = function(prop)  {
 		var _super 		= this.prototype;
-		initializing 	= true;// 	Instantiate a base class (but only create the instance, dont run the init constructor)
+		initializing 	= true;// 	Instantiate a base class (but only create the instance, don’t run the init constructor)
 		var prototype 	= new this();
 		initializing 	= false;
 
@@ -15,7 +15,7 @@
 					return function() {
 						var tmp 	= this._super;
 						this._super = _super[name];// Add a new ._super() method that is the same method  but on the super-class
-						var ret 	= fn.apply(this, arguments);// 	The method only need to be bound temporarily, so we remove it when were done executing
+						var ret 	= fn.apply(this, arguments);// 	The method only needs to be bound temporarily, so we remove it when we’re done executing
 						this._super = tmp;
 						return ret;
 					};


### PR DESCRIPTION
## Summary
- fix comment typos in `Class.js`

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_683fefae56b0832a8caa479ec13aa340